### PR TITLE
Fix digital object EAD publication status

### DIFF
--- a/backend/model/ead3_exporter_addon.rb
+++ b/backend/model/ead3_exporter_addon.rb
@@ -412,7 +412,7 @@ class EAD3Serializer < EADSerializer
          atts['role'] = file_version['use_statement'] if file_version['use_statement']
          atts['linktitle'] = file_version['caption'] if file_version['caption']
          atts['href'] = file_version['file_uri']
-         atts['audience'] = 'internal' unless is_digital_object_published?(digital_object, file_version)
+         atts['audience'] = file_version['publish'] ? 'external' : 'internal'
          xml.dao( atts )
        end
        xml.descriptivenote{ sanitize_mixed_content(content, xml, fragments, true) } if content


### PR DESCRIPTION
Publication status settings were overly broad, pulling in unpublished digital objects to then be represented in the public EAD files. This takes care of preventing unpublished digital objects from being made public in the EAD.
